### PR TITLE
Switch IDs from UUID v4 to v7

### DIFF
--- a/inmem/case_execution_test.go
+++ b/inmem/case_execution_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestCaseExecutionReader_GetCaseExecution(t *testing.T) {

--- a/inmem/db.go
+++ b/inmem/db.go
@@ -4,21 +4,21 @@ import (
 	"sync"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/google/uuid"
 
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 type DB struct {
 	mu               *sync.RWMutex
 	contexts         mapset.Set[string]
 	groups           mapset.Set[groupKey]
-	tests            map[uuid.UUID]*test.Test
-	defaultInputs    map[uuid.UUID]*test.Payload
+	tests            map[uuid.V7]*test.Test
+	defaultInputs    map[uuid.V7]*test.Payload
 	testExecs        map[test.TestExecutionID]*test.TestExecution
 	testExecPayloads map[test.TestExecutionID][]byte
 	caseExecs        map[caseExecKey]*test.CaseExecution
-	execLogs         map[uuid.UUID]*test.Log
+	execLogs         map[uuid.V7]*test.Log
 }
 
 func NewDB() *DB {
@@ -26,11 +26,11 @@ func NewDB() *DB {
 		mu:               new(sync.RWMutex),
 		contexts:         mapset.NewSet[string](),
 		groups:           mapset.NewSet[groupKey](),
-		tests:            map[uuid.UUID]*test.Test{},
-		defaultInputs:    map[uuid.UUID]*test.Payload{},
+		tests:            map[uuid.V7]*test.Test{},
+		defaultInputs:    map[uuid.V7]*test.Payload{},
 		testExecs:        map[test.TestExecutionID]*test.TestExecution{},
 		testExecPayloads: map[test.TestExecutionID][]byte{},
 		caseExecs:        map[caseExecKey]*test.CaseExecution{},
-		execLogs:         map[uuid.UUID]*test.Log{},
+		execLogs:         map[uuid.V7]*test.Log{},
 	}
 }

--- a/inmem/execution_log.go
+++ b/inmem/execution_log.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"slices"
 
-	"github.com/google/uuid"
-
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -23,7 +22,7 @@ func NewLogReader(db *DB) *LogReader {
 	return &LogReader{db: db}
 }
 
-func (e *LogReader) GetLog(_ context.Context, id uuid.UUID) (*test.Log, error) {
+func (e *LogReader) GetLog(_ context.Context, id uuid.V7) (*test.Log, error) {
 	execLog, ok := e.db.execLogs[id]
 	if !ok {
 		return nil, test.ErrorLogNotFound
@@ -76,7 +75,7 @@ func (e *LogWriter) CreateLog(_ context.Context, log *test.Log) error {
 	return nil
 }
 
-func (e *LogWriter) DeleteLog(_ context.Context, id uuid.UUID) error {
+func (e *LogWriter) DeleteLog(_ context.Context, id uuid.V7) error {
 	e.db.mu.Lock()
 	defer e.db.mu.Unlock()
 	delete(e.db.execLogs, id)

--- a/inmem/execution_log_test.go
+++ b/inmem/execution_log_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestLogReader_GetLog(t *testing.T) {

--- a/inmem/test.go
+++ b/inmem/test.go
@@ -6,10 +6,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -25,7 +24,7 @@ func NewTestReader(db *DB) *TestReader {
 	return &TestReader{db: db}
 }
 
-func (t *TestReader) GetTest(_ context.Context, id uuid.UUID) (*test.Test, error) {
+func (t *TestReader) GetTest(_ context.Context, id uuid.V7) (*test.Test, error) {
 	t.db.mu.RLock()
 	defer t.db.mu.RUnlock()
 
@@ -57,7 +56,7 @@ func (t *TestReader) ListTests(_ context.Context, contextID string, groupID stri
 	return tests, nil
 }
 
-func (t *TestReader) GetTestDefaultInput(_ context.Context, testID uuid.UUID) (*test.Payload, error) {
+func (t *TestReader) GetTestDefaultInput(_ context.Context, testID uuid.V7) (*test.Payload, error) {
 	t.db.mu.RLock()
 	defer t.db.mu.RUnlock()
 

--- a/inmem/test_execution.go
+++ b/inmem/test_execution.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"slices"
 
-	"github.com/google/uuid"
-
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -48,7 +47,7 @@ func (t *TestExecutionReader) GetTestExecutionInput(_ context.Context, id test.T
 	}, nil
 }
 
-func (t *TestExecutionReader) ListTestExecutions(_ context.Context, testID uuid.UUID, filter *test.TestExecutionListFilter) (test.TestExecutionList, error) {
+func (t *TestExecutionReader) ListTestExecutions(_ context.Context, testID uuid.V7, filter *test.TestExecutionListFilter) (test.TestExecutionList, error) {
 	t.db.mu.RLock()
 	defer t.db.mu.RUnlock()
 

--- a/inmem/test_execution_test.go
+++ b/inmem/test_execution_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestTestExecutionReader_GetTestExecution(t *testing.T) {
@@ -230,7 +230,7 @@ func TestTestExecutionWriter_ResetTestExecution(t *testing.T) {
 			existing := fake.GenTestExec(testID)
 
 			var staleCaseExecIDs []test.CaseExecutionID
-			var staleLogIDs []uuid.UUID
+			var staleLogIDs []uuid.V7
 
 			if tt.existingTestExec {
 				db.testExecs[existing.ID] = existing

--- a/inmem/test_test.go
+++ b/inmem/test_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestTestReader_GetTest(t *testing.T) {

--- a/internal/fake/event.go
+++ b/internal/fake/event.go
@@ -2,10 +2,10 @@ package fake
 
 import (
 	eventsv1 "github.com/annexsh/annex-proto/go/gen/annex/events/v1"
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func GenExecEvent(testExecID test.TestExecutionID) *eventsv1.Event {

--- a/internal/fake/test.go
+++ b/internal/fake/test.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"go.temporal.io/sdk/converter"
 
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 type TestOptions func(opts *testOptions)
@@ -71,7 +71,7 @@ func GenTest(opts ...TestOptions) *test.Test {
 	}
 }
 
-func GenScheduledTestExec(testID uuid.UUID) *test.ScheduledTestExecution {
+func GenScheduledTestExec(testID uuid.V7) *test.ScheduledTestExecution {
 	return &test.ScheduledTestExecution{
 		ID:           test.NewTestExecutionID(),
 		TestID:       testID,
@@ -95,7 +95,7 @@ func GenFinishedTestExec(testExecID test.TestExecutionID, err *string) *test.Fin
 	}
 }
 
-func GenTestExec(testID uuid.UUID) *test.TestExecution {
+func GenTestExec(testID uuid.V7) *test.TestExecution {
 	return &test.TestExecution{
 		ID:           test.NewTestExecutionID(),
 		TestID:       testID,

--- a/internal/fake/workflow_history.go
+++ b/internal/fake/workflow_history.go
@@ -3,7 +3,6 @@ package fake
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/failure/v1"
@@ -16,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var _ client.HistoryEventIterator = (*iterator)(nil)
@@ -62,11 +62,11 @@ func parseTime(timeStr string) *timestamppb.Timestamp {
 // - Test execution finish - error (case 2)
 func GenCaseFailureHistory(
 	testExecID test.TestExecutionID,
-	testExecLogID uuid.UUID, // log published by event 7 local activity
+	testExecLogID uuid.V7, // log published by event 7 local activity
 	successCaseExecID test.CaseExecutionID,
 	failureCaseExecID test.CaseExecutionID,
 ) *history.History {
-	logResult := struct{ LogID uuid.UUID }{LogID: testExecLogID}
+	logResult := struct{ LogID uuid.V7 }{LogID: testExecLogID}
 
 	dc := converter.GetDefaultDataConverter()
 	logPayload, err := dc.ToPayload(logResult)

--- a/internal/fake/workflow_run.go
+++ b/internal/fake/workflow_run.go
@@ -3,8 +3,9 @@ package fake
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
+
+	"github.com/annexsh/annex/uuid"
 )
 
 var _ client.WorkflowRun = (*WorkflowRun)(nil)

--- a/internal/fake/workflower.go
+++ b/internal/fake/workflower.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"
 	"go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/annexsh/annex/uuid"
 )
 
 const WorkflowName = "FakeWorkflow"

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -6,48 +6,49 @@ import (
 	"time"
 
 	paginationv1 "github.com/annexsh/annex-proto/go/gen/annex/common/pagination/v1"
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/annexsh/annex/uuid"
 )
 
 type PaginatedRequest interface {
 	GetNextPageToken() string
 }
 
-func DecodeNextPageToken(req PaginatedRequest) (time.Time, uuid.UUID, error) {
+func DecodeNextPageToken(req PaginatedRequest) (time.Time, uuid.V7, error) {
 	if req == nil {
-		return time.Time{}, uuid.UUID{}, errors.New("paginated request cannot be nil")
+		return time.Time{}, uuid.V7{}, errors.New("paginated request cannot be nil")
 	}
 
 	encoded := req.GetNextPageToken()
 	if encoded == "" {
-		return time.Time{}, uuid.UUID{}, nil
+		return time.Time{}, uuid.V7{}, nil
 	}
 
 	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
-		return time.Time{}, uuid.UUID{}, err
+		return time.Time{}, uuid.V7{}, err
 	}
 
 	var tkn paginationv1.PaginationToken
 	if err = proto.Unmarshal(decoded, &tkn); err != nil {
-		return time.Time{}, uuid.UUID{}, err
+		return time.Time{}, uuid.V7{}, err
 	}
 
 	lastID, err := uuid.Parse(tkn.LastId)
 	if err != nil {
-		return time.Time{}, uuid.UUID{}, err
+		return time.Time{}, uuid.V7{}, err
 	}
 
 	if tkn.LastTimestamp == nil {
-		return time.Time{}, uuid.UUID{}, errors.New("next page token does not contain last timestamp")
+		return time.Time{}, uuid.V7{}, errors.New("next page token does not contain last timestamp")
 	}
 
 	return tkn.LastTimestamp.AsTime(), lastID, nil
 }
 
-func EncodeNextPageToken(lastTimestamp time.Time, lastID uuid.UUID) (string, error) {
+func EncodeNextPageToken(lastTimestamp time.Time, lastID uuid.V7) (string, error) {
 	tkn := &paginationv1.PaginationToken{
 		LastTimestamp: timestamppb.New(lastTimestamp),
 		LastId:        lastID.String(),

--- a/postgres/log.go
+++ b/postgres/log.go
@@ -3,11 +3,10 @@ package postgres
 import (
 	"context"
 
-	"github.com/google/uuid"
-
 	"github.com/annexsh/annex/postgres/sqlc"
 
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -23,7 +22,7 @@ func NewLogReader(db *DB) *LogReader {
 	return &LogReader{db: db}
 }
 
-func (e *LogReader) GetLog(ctx context.Context, id uuid.UUID) (*test.Log, error) {
+func (e *LogReader) GetLog(ctx context.Context, id uuid.V7) (*test.Log, error) {
 	execLog, err := e.db.GetLog(ctx, id)
 	if err != nil {
 		return nil, err
@@ -59,6 +58,6 @@ func (e *LogWriter) CreateLog(ctx context.Context, log *test.Log) error {
 	})
 }
 
-func (e *LogWriter) DeleteLog(ctx context.Context, id uuid.UUID) error {
+func (e *LogWriter) DeleteLog(ctx context.Context, id uuid.V7) error {
 	return e.db.DeleteLog(ctx, id)
 }

--- a/postgres/sqlc.yaml
+++ b/postgres/sqlc.yaml
@@ -18,12 +18,12 @@ overrides:
   go:
     overrides:
       - db_type: "uuid"
-        go_type: "github.com/google/uuid.UUID"
+        go_type: "github.com/annexsh/annex/uuid.V7"
       - db_type: "uuid"
         nullable: true
         go_type:
-          import: "github.com/google/uuid"
-          type: "UUID"
+          import: "github.com/annexsh/annex/uuid"
+          type: "V7"
           pointer: true
       - db_type: "pg_catalog.timestamp"
         go_type:

--- a/postgres/sqlc/log.sql.go
+++ b/postgres/sqlc/log.sql.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/annexsh/annex/test"
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 const createLog = `-- name: CreateLog :exec
@@ -19,7 +19,7 @@ VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 type CreateLogParams struct {
-	ID              uuid.UUID             `json:"id"`
+	ID              uuid.V7               `json:"id"`
 	TestExecutionID test.TestExecutionID  `json:"test_execution_id"`
 	CaseExecutionID *test.CaseExecutionID `json:"case_execution_id"`
 	Level           string                `json:"level"`
@@ -45,7 +45,7 @@ FROM logs
 WHERE id = $1
 `
 
-func (q *Queries) DeleteLog(ctx context.Context, id uuid.UUID) error {
+func (q *Queries) DeleteLog(ctx context.Context, id uuid.V7) error {
 	_, err := q.db.Exec(ctx, deleteLog, id)
 	return err
 }
@@ -56,7 +56,7 @@ FROM logs
 WHERE id = $1
 `
 
-func (q *Queries) GetLog(ctx context.Context, id uuid.UUID) (*Log, error) {
+func (q *Queries) GetLog(ctx context.Context, id uuid.V7) (*Log, error) {
 	row := q.db.QueryRow(ctx, getLog, id)
 	var i Log
 	err := row.Scan(

--- a/postgres/sqlc/models.go
+++ b/postgres/sqlc/models.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/annexsh/annex/test"
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 type CaseExecution struct {
@@ -31,7 +31,7 @@ type Group struct {
 }
 
 type Log struct {
-	ID              uuid.UUID             `json:"id"`
+	ID              uuid.V7               `json:"id"`
 	TestExecutionID test.TestExecutionID  `json:"test_execution_id"`
 	CaseExecutionID *test.CaseExecutionID `json:"case_execution_id"`
 	Level           string                `json:"level"`
@@ -42,20 +42,20 @@ type Log struct {
 type Test struct {
 	ContextID  string    `json:"context_id"`
 	GroupID    string    `json:"group_id"`
-	ID         uuid.UUID `json:"id"`
+	ID         uuid.V7   `json:"id"`
 	Name       string    `json:"name"`
 	HasInput   bool      `json:"has_input"`
 	CreateTime time.Time `json:"create_time"`
 }
 
 type TestDefaultInput struct {
-	TestID uuid.UUID `json:"test_id"`
-	Data   []byte    `json:"data"`
+	TestID uuid.V7 `json:"test_id"`
+	Data   []byte  `json:"data"`
 }
 
 type TestExecution struct {
 	ID           test.TestExecutionID `json:"id"`
-	TestID       uuid.UUID            `json:"test_id"`
+	TestID       uuid.V7              `json:"test_id"`
 	HasInput     bool                 `json:"has_input"`
 	ScheduleTime time.Time            `json:"schedule_time"`
 	StartTime    *time.Time           `json:"start_time"`

--- a/postgres/sqlc/querier.go
+++ b/postgres/sqlc/querier.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/annexsh/annex/test"
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 type Querier interface {
@@ -22,12 +22,12 @@ type Querier interface {
 	CreateTestExecution(ctx context.Context, arg CreateTestExecutionParams) (*TestExecution, error)
 	CreateTestExecutionInput(ctx context.Context, arg CreateTestExecutionInputParams) error
 	DeleteCaseExecution(ctx context.Context, arg DeleteCaseExecutionParams) error
-	DeleteLog(ctx context.Context, id uuid.UUID) error
+	DeleteLog(ctx context.Context, id uuid.V7) error
 	GetCaseExecution(ctx context.Context, arg GetCaseExecutionParams) (*CaseExecution, error)
-	GetLog(ctx context.Context, id uuid.UUID) (*Log, error)
-	GetTest(ctx context.Context, id uuid.UUID) (*Test, error)
+	GetLog(ctx context.Context, id uuid.V7) (*Log, error)
+	GetTest(ctx context.Context, id uuid.V7) (*Test, error)
 	GetTestByName(ctx context.Context, arg GetTestByNameParams) (*Test, error)
-	GetTestDefaultInput(ctx context.Context, testID uuid.UUID) (*TestDefaultInput, error)
+	GetTestDefaultInput(ctx context.Context, testID uuid.V7) (*TestDefaultInput, error)
 	GetTestExecution(ctx context.Context, id test.TestExecutionID) (*TestExecution, error)
 	GetTestExecutionInput(ctx context.Context, testExecutionID test.TestExecutionID) (*TestExecutionInput, error)
 	GroupExists(ctx context.Context, arg GroupExistsParams) error

--- a/postgres/sqlc/test.sql.go
+++ b/postgres/sqlc/test.sql.go
@@ -8,7 +8,7 @@ package sqlc
 import (
 	"context"
 
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 const createTest = `-- name: CreateTest :one
@@ -21,11 +21,11 @@ RETURNING context_id, group_id, id, name, has_input, create_time
 `
 
 type CreateTestParams struct {
-	ContextID string    `json:"context_id"`
-	GroupID   string    `json:"group_id"`
-	ID        uuid.UUID `json:"id"`
-	Name      string    `json:"name"`
-	HasInput  bool      `json:"has_input"`
+	ContextID string  `json:"context_id"`
+	GroupID   string  `json:"group_id"`
+	ID        uuid.V7 `json:"id"`
+	Name      string  `json:"name"`
+	HasInput  bool    `json:"has_input"`
 }
 
 func (q *Queries) CreateTest(ctx context.Context, arg CreateTestParams) (*Test, error) {
@@ -56,8 +56,8 @@ ON CONFLICT (test_id) DO UPDATE
 `
 
 type CreateTestDefaultInputParams struct {
-	TestID uuid.UUID `json:"test_id"`
-	Data   []byte    `json:"data"`
+	TestID uuid.V7 `json:"test_id"`
+	Data   []byte  `json:"data"`
 }
 
 func (q *Queries) CreateTestDefaultInput(ctx context.Context, arg CreateTestDefaultInputParams) error {
@@ -71,7 +71,7 @@ FROM tests
 WHERE id = $1
 `
 
-func (q *Queries) GetTest(ctx context.Context, id uuid.UUID) (*Test, error) {
+func (q *Queries) GetTest(ctx context.Context, id uuid.V7) (*Test, error) {
 	row := q.db.QueryRow(ctx, getTest, id)
 	var i Test
 	err := row.Scan(
@@ -117,7 +117,7 @@ FROM test_default_inputs
 WHERE test_id = $1
 `
 
-func (q *Queries) GetTestDefaultInput(ctx context.Context, testID uuid.UUID) (*TestDefaultInput, error) {
+func (q *Queries) GetTestDefaultInput(ctx context.Context, testID uuid.V7) (*TestDefaultInput, error) {
 	row := q.db.QueryRow(ctx, getTestDefaultInput, testID)
 	var i TestDefaultInput
 	err := row.Scan(&i.TestID, &i.Data)

--- a/postgres/sqlc/test_execution.sql.go
+++ b/postgres/sqlc/test_execution.sql.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/annexsh/annex/test"
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 const createTestExecution = `-- name: CreateTestExecution :one
@@ -28,7 +28,7 @@ RETURNING id, test_id, has_input, schedule_time, start_time, finish_time, error
 
 type CreateTestExecutionParams struct {
 	ID           test.TestExecutionID `json:"id"`
-	TestID       uuid.UUID            `json:"test_id"`
+	TestID       uuid.V7              `json:"test_id"`
 	HasInput     bool                 `json:"has_input"`
 	ScheduleTime time.Time            `json:"schedule_time"`
 }
@@ -117,10 +117,10 @@ LIMIT ($5::integer)
 `
 
 type ListTestExecutionsParams struct {
-	TestID              uuid.UUID  `json:"test_id"`
+	TestID              uuid.V7    `json:"test_id"`
 	LastScheduleTime    *time.Time `json:"last_schedule_time"`
-	LastExecID          *uuid.UUID `json:"last_exec_id"`
-	LastTestExecutionID uuid.UUID  `json:"last_test_execution_id"`
+	LastExecID          *uuid.V7   `json:"last_exec_id"`
+	LastTestExecutionID uuid.V7    `json:"last_test_execution_id"`
 	PageSize            *int32     `json:"page_size"`
 }
 

--- a/postgres/test.go
+++ b/postgres/test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/annexsh/annex/postgres/sqlc"
-
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -25,7 +24,7 @@ func NewTestReader(db *DB) *TestReader {
 	return &TestReader{db: db}
 }
 
-func (t *TestReader) GetTest(ctx context.Context, id uuid.UUID) (*test.Test, error) {
+func (t *TestReader) GetTest(ctx context.Context, id uuid.V7) (*test.Test, error) {
 	tt, err := t.db.GetTest(ctx, id)
 	if err != nil {
 		return nil, err
@@ -45,7 +44,7 @@ func (t *TestReader) ListTests(ctx context.Context, contextID string, groupID st
 	return marshalTests(tests), nil
 }
 
-func (t *TestReader) GetTestDefaultInput(ctx context.Context, testID uuid.UUID) (*test.Payload, error) {
+func (t *TestReader) GetTestDefaultInput(ctx context.Context, testID uuid.V7) (*test.Payload, error) {
 	payload, err := t.db.GetTestDefaultInput(ctx, testID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/postgres/test_execution.go
+++ b/postgres/test_execution.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
-
-	"github.com/annexsh/annex/postgres/sqlc"
-
 	"github.com/annexsh/annex/internal/ptr"
+	"github.com/annexsh/annex/postgres/sqlc"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 var (
@@ -41,7 +39,7 @@ func (t *TestExecutionReader) GetTestExecutionInput(ctx context.Context, id test
 	return marshalTestExecPayload(payload), nil
 }
 
-func (t *TestExecutionReader) ListTestExecutions(ctx context.Context, testID uuid.UUID, filter *test.TestExecutionListFilter) (test.TestExecutionList, error) {
+func (t *TestExecutionReader) ListTestExecutions(ctx context.Context, testID uuid.V7, filter *test.TestExecutionListFilter) (test.TestExecutionList, error) {
 	params := sqlc.ListTestExecutionsParams{
 		TestID:           testID,
 		LastScheduleTime: filter.LastScheduleTime,

--- a/server/util.go
+++ b/server/util.go
@@ -6,12 +6,12 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/google/uuid"
 	"github.com/lmittmann/tint"
 	"github.com/temporalio/cli/temporalcli/devserver"
 
 	"github.com/annexsh/annex/internal/rpc"
 	"github.com/annexsh/annex/log"
+	"github.com/annexsh/annex/uuid"
 	"github.com/annexsh/annex/workflowservice"
 )
 

--- a/test/id.go
+++ b/test/id.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 const (
@@ -14,15 +14,11 @@ const (
 )
 
 type TestExecutionID struct {
-	uuid.UUID
+	uuid.V7
 }
 
 func (i TestExecutionID) WorkflowID() string {
 	return testWorkflowPrefix + i.String()
-}
-
-func (i TestExecutionID) IsEmpty() bool {
-	return i.UUID == uuid.Nil
 }
 
 func NewTestExecutionID() TestExecutionID {

--- a/test/repository.go
+++ b/test/repository.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 type Repository interface {
@@ -49,9 +49,9 @@ type TestReadWriter interface {
 }
 
 type TestReader interface {
-	GetTest(ctx context.Context, id uuid.UUID) (*Test, error)
+	GetTest(ctx context.Context, id uuid.V7) (*Test, error)
 	ListTests(ctx context.Context, contextID string, groupID string) (TestList, error)
-	GetTestDefaultInput(ctx context.Context, testID uuid.UUID) (*Payload, error)
+	GetTestDefaultInput(ctx context.Context, testID uuid.V7) (*Payload, error)
 }
 
 type TestWriter interface {
@@ -67,7 +67,7 @@ type TestExecutionReadWriter interface {
 type TestExecutionReader interface {
 	GetTestExecution(ctx context.Context, id TestExecutionID) (*TestExecution, error)
 	GetTestExecutionInput(ctx context.Context, id TestExecutionID) (*Payload, error)
-	ListTestExecutions(ctx context.Context, testID uuid.UUID, filter *TestExecutionListFilter) (TestExecutionList, error)
+	ListTestExecutions(ctx context.Context, testID uuid.V7, filter *TestExecutionListFilter) (TestExecutionList, error)
 }
 
 type TestExecutionWriter interface {
@@ -100,13 +100,13 @@ type LogReadWriter interface {
 }
 
 type LogReader interface {
-	GetLog(ctx context.Context, id uuid.UUID) (*Log, error)
+	GetLog(ctx context.Context, id uuid.V7) (*Log, error)
 	ListLogs(ctx context.Context, testExecID TestExecutionID) (LogList, error)
 }
 
 type LogWriter interface {
 	CreateLog(ctx context.Context, log *Log) error
-	DeleteLog(ctx context.Context, id uuid.UUID) error
+	DeleteLog(ctx context.Context, id uuid.V7) error
 }
 
 type ResetRollback func(ctx context.Context) error

--- a/test/types.go
+++ b/test/types.go
@@ -3,13 +3,13 @@ package test
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/annexsh/annex/uuid"
 )
 
 type TestDefinition struct {
 	ContextID    string
 	GroupID      string
-	TestID       uuid.UUID
+	TestID       uuid.V7
 	Name         string
 	DefaultInput *Payload
 }
@@ -17,7 +17,7 @@ type TestDefinition struct {
 type Test struct {
 	ContextID  string
 	GroupID    string
-	ID         uuid.UUID
+	ID         uuid.V7
 	Name       string
 	HasInput   bool
 	CreateTime time.Time
@@ -32,7 +32,7 @@ type Payload struct {
 
 type TestExecution struct {
 	ID           TestExecutionID
-	TestID       uuid.UUID
+	TestID       uuid.V7
 	HasInput     bool
 	ScheduleTime time.Time
 	StartTime    *time.Time
@@ -46,12 +46,12 @@ type ResetTestExecution struct {
 	ID                  TestExecutionID
 	ResetTime           time.Time
 	StaleCaseExecutions []CaseExecutionID
-	StaleLogs           []uuid.UUID
+	StaleLogs           []uuid.V7
 }
 
 type ScheduledTestExecution struct {
 	ID           TestExecutionID
-	TestID       uuid.UUID
+	TestID       uuid.V7
 	Payload      []byte
 	ScheduleTime time.Time
 }
@@ -69,7 +69,7 @@ type FinishedTestExecution struct {
 
 type TestExecutionListFilter struct {
 	LastScheduleTime    *time.Time // required when listing next page
-	LastTestExecutionID *uuid.UUID // required when listing next page
+	LastTestExecutionID *uuid.V7   // required when listing next page
 	PageSize            uint32
 }
 
@@ -106,7 +106,7 @@ type FinishedCaseExecution struct {
 }
 
 type Log struct {
-	ID              uuid.UUID
+	ID              uuid.V7
 	TestExecutionID TestExecutionID
 	CaseExecutionID *CaseExecutionID
 	Level           string

--- a/testservice/case_execution_test.go
+++ b/testservice/case_execution_test.go
@@ -7,13 +7,13 @@ import (
 
 	"connectrpc.com/connect"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/internal/ptr"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestService_AckCaseExecutionScheduled(t *testing.T) {

--- a/testservice/log.go
+++ b/testservice/log.go
@@ -7,11 +7,11 @@ import (
 	"connectrpc.com/connect"
 	eventsv1 "github.com/annexsh/annex-proto/go/gen/annex/events/v1"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 
 	"github.com/annexsh/annex/event"
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func (s *Service) PublishLog(

--- a/testservice/log_test.go
+++ b/testservice/log_test.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -14,6 +13,7 @@ import (
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/internal/ptr"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestService_PublishTestExecutionLog(t *testing.T) {

--- a/testservice/test.go
+++ b/testservice/test.go
@@ -7,9 +7,9 @@ import (
 
 	"connectrpc.com/connect"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func (s *Service) RegisterTests(

--- a/testservice/test_execution.go
+++ b/testservice/test_execution.go
@@ -7,11 +7,11 @@ import (
 	"connectrpc.com/connect"
 	eventsv1 "github.com/annexsh/annex-proto/go/gen/annex/events/v1"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 
 	"github.com/annexsh/annex/event"
 	"github.com/annexsh/annex/internal/pagination"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func (s *Service) GetTestExecution(
@@ -84,7 +84,7 @@ func (s *Service) ListTestExecutions(
 	if hasNextPage {
 		testExecs = testExecs[:len(testExecs)-1] // remove page buffer item
 		lastExec := testExecs[len(testExecs)-1]
-		res.NextPageToken, err = pagination.EncodeNextPageToken(lastExec.ScheduleTime.UTC(), lastExec.ID.UUID)
+		res.NextPageToken, err = pagination.EncodeNextPageToken(lastExec.ScheduleTime.UTC(), lastExec.ID.V7)
 		if err != nil {
 			return nil, err
 		}

--- a/testservice/test_test.go
+++ b/testservice/test_test.go
@@ -7,12 +7,12 @@ import (
 
 	"connectrpc.com/connect"
 	testsv1 "github.com/annexsh/annex-proto/go/gen/annex/tests/v1"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 func TestService_RegisterTest(t *testing.T) {

--- a/testservice/util_test.go
+++ b/testservice/util_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/annexsh/annex/event"
 	"github.com/annexsh/annex/inmem"
 	"github.com/annexsh/annex/internal/fake"
 	"github.com/annexsh/annex/test"
+	"github.com/annexsh/annex/uuid"
 )
 
 type fakeDeps struct {
@@ -29,7 +29,7 @@ func newService() (*Service, *fakeDeps) {
 	}
 }
 
-func createTestExec(t *testing.T, ctx context.Context, repo test.Repository, testID uuid.UUID, failure *string) *test.TestExecution {
+func createTestExec(t *testing.T, ctx context.Context, repo test.Repository, testID uuid.V7, failure *string) *test.TestExecution {
 	te, err := repo.CreateScheduledTestExecution(ctx, fake.GenScheduledTestExec(testID))
 	require.NoError(t, err)
 	te, err = repo.UpdateStartedTestExecution(ctx, fake.GenStartedTestExec(te.ID))

--- a/uuid/v7.go
+++ b/uuid/v7.go
@@ -1,0 +1,44 @@
+package uuid
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const version7 = "VERSION_7"
+
+type V7 struct {
+	uuid.UUID
+}
+
+func (u V7) Empty() bool {
+	return u.UUID == uuid.Nil
+}
+
+func (u V7) Before(id V7) bool {
+	return u.String() < id.String()
+}
+
+func (u V7) After(id V7) bool {
+	return u.String() > id.String()
+}
+
+func New() V7 {
+	return V7{uuid.Must(uuid.NewV7())}
+}
+
+func NewString() string {
+	return New().String()
+}
+
+func Parse(s string) (V7, error) {
+	u, err := uuid.Parse(s)
+	if err != nil {
+		return V7{}, err
+	}
+	if u.Version().String() != version7 {
+		return V7{}, fmt.Errorf("uuid is not %s: found %s", version7, u.Version().String())
+	}
+	return V7{u}, err
+}

--- a/uuid/v7_test.go
+++ b/uuid/v7_test.go
@@ -1,0 +1,48 @@
+package uuid
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	id := New()
+	assert.Equal(t, version7, id.Version().String())
+}
+
+func TestNewString(t *testing.T) {
+	str := NewString()
+	id, err := uuid.Parse(str)
+	require.NoError(t, err)
+
+	assert.Equal(t, version7, id.Version().String())
+}
+
+func TestParse(t *testing.T) {
+	v7str := uuid.Must(uuid.NewV7()).String()
+	v4str := uuid.NewString()
+
+	v7id, err := Parse(v7str)
+	require.NoError(t, err)
+	assert.False(t, v7id.Empty())
+
+	_, err = Parse(v4str)
+	assert.EqualError(t, err, "uuid is not VERSION_7: found VERSION_4")
+}
+
+func TestV7_BeforeAfter(t *testing.T) {
+	a := New()
+	b := New()
+	assert.True(t, a.Before(b))
+	assert.False(t, a.After(b))
+	assert.False(t, b.Before(a))
+	assert.True(t, b.After(a))
+}
+
+func TestV7_Empty(t *testing.T) {
+	var empty V7
+	assert.True(t, empty.Empty())
+}


### PR DESCRIPTION
## Description

Using non-time ordered UUIDs such as v4 is bad for database performance when used as a primary key due to poor database index locality.

On the other hand, v7 is time ordered and sequential, which solves the problem mentioned above. See BuildKite's transition to UUID v7 for more information: https://buildkite.com/blog/goodbye-integers-hello-uuids.

This change transitions from using UUID v4 to v7 in order to improve database indexing.