### PR TITLE
Fix list test execution logs ordering

### DIFF
--- a/postgres/queries/log.sql
+++ b/postgres/queries/log.sql
@@ -12,7 +12,6 @@ SELECT *
 FROM logs
 WHERE (test_execution_id = @test_execution_id)
   AND (sqlc.narg('offset_id')::uuid IS NULL OR id < sqlc.narg('offset_id')::uuid)
-ORDER BY id DESC
 LIMIT @page_size;
 
 -- name: DeleteLog :exec

--- a/postgres/sqlc/log.sql.go
+++ b/postgres/sqlc/log.sql.go
@@ -75,7 +75,6 @@ SELECT id, test_execution_id, case_execution_id, level, message, create_time
 FROM logs
 WHERE (test_execution_id = $1)
   AND ($2::uuid IS NULL OR id < $2::uuid)
-ORDER BY id DESC
 LIMIT $3
 `
 

--- a/server/all_in_one_server.go
+++ b/server/all_in_one_server.go
@@ -113,6 +113,7 @@ func ServeAllInOne(ctx context.Context, cfg AllInOneConfig) error {
 	temporalClient, err := client.NewLazyClient(client.Options{
 		HostPort:  cfg.Temporal.HostPort,
 		Namespace: workflowservice.Namespace,
+		Logger:    logger.With("component", "temporal"),
 	})
 	if err != nil {
 		return err

--- a/sqlite/queries/log.sql
+++ b/sqlite/queries/log.sql
@@ -13,7 +13,6 @@ FROM logs
 WHERE (test_execution_id = @test_execution_id)
   -- Cast as text required below since sqlc.narg doesn't work with overridden column type
   AND (CAST(sqlc.narg('offset_id') AS TEXT) IS NULL OR id < CAST(sqlc.narg('offset_id') AS TEXT))
-ORDER BY id DESC
 LIMIT @page_size;
 
 -- name: DeleteLog :exec

--- a/sqlite/sqlc/log.sql.go
+++ b/sqlite/sqlc/log.sql.go
@@ -76,7 +76,6 @@ FROM logs
 WHERE (test_execution_id = ?1)
   -- Cast as text required below since sqlc.narg doesn't work with overridden column type
   AND (CAST(?2 AS TEXT) IS NULL OR id < CAST(?2 AS TEXT))
-ORDER BY id DESC
 LIMIT ?3
 `
 


### PR DESCRIPTION
### Changes

- List test execution logs in ascending order instead of descending
- Set Temporal client logger