### PR TITLE
Add Temporal client logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nats-io/nats.go v1.37.0
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.9.0
-	go.temporal.io/api v1.39.0
+	go.temporal.io/api v1.38.0
 	go.temporal.io/sdk v1.29.1
 	go.temporal.io/server v1.25.1
 	golang.org/x/net v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ go.opentelemetry.io/otel/sdk/metric v1.31.0 h1:i9hxxLJF/9kkvfHppyLL55aW7iIJz4Jjx
 go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/trace v1.31.0 h1:ffjsj1aRouKewfr85U2aGagJ46+MvodynlQ1HYdmJys=
 go.opentelemetry.io/otel/trace v1.31.0/go.mod h1:TXZkRk7SM2ZQLtR6eoAWQFIHPvzQ06FJAsO1tJg480A=
-go.temporal.io/api v1.39.0 h1:pbhcfvNDB7mllb8lIBqPcg+m6LMG/IhTpdiFxe+0mYk=
-go.temporal.io/api v1.39.0/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
+go.temporal.io/api v1.38.0 h1:L5i+Ai7UoBa2Gq/goVHLY32064AgawxPDLkKm4I7fu4=
+go.temporal.io/api v1.38.0/go.mod h1:fmh06EjstyrPp6SHbjJo7yYHBfHamPE4SytM+2NRejc=
 go.temporal.io/sdk v1.29.1 h1:y+sUMbUhTU9rj50mwIZAPmcXCtgUdOWS9xHDYRYSgZ0=
 go.temporal.io/sdk v1.29.1/go.mod h1:kp//DRvn3CqQVBCtjL51Oicp9wrZYB2s6row1UgzcKQ=
 go.temporal.io/server v1.25.1 h1:iDkzzDMdmOPZUctLegF5kWY/h1W/MTbMZ8hsBkHBIV4=

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -98,15 +98,13 @@ func (s *Server) Serve() error {
 }
 
 func (s *Server) Stop() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := s.httpSrv.Shutdown(ctx)
 	if s.grpcSrv != nil {
-		s.grpcSrv.GracefulStop()
+		s.grpcSrv.Stop()
 	}
-	if s.httpSrv != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		return s.httpSrv.Shutdown(ctx)
-	}
-	return nil
+	return err
 }
 
 func (s *Server) ConnectAddress() string {

--- a/server/event_server.go
+++ b/server/event_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -17,8 +16,7 @@ import (
 )
 
 func ServeEventService(ctx context.Context, cfg EventServiceConfig) error {
-	logger := log.NewLogger("app", "annex-event-service")
-
+	logger := log.NewLogger("service", "event_service")
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	testClient := testsv1connect.NewTestServiceClient(httpClient, cfg.TestServiceURL)
 
@@ -55,7 +53,7 @@ func ServeEventService(ctx context.Context, cfg EventServiceConfig) error {
 
 	eventSvc := eventservice.New(pubSub, testClient, eventservice.WithLogger(logger))
 
-	srv := rpc.NewServer(fmt.Sprint(":", cfg.Port))
+	srv := rpc.NewServer(getHostPort(cfg.Port))
 	path, handler := eventsv1connect.NewEventServiceHandler(eventSvc, rpc.WithConnectInterceptors(logger))
 	srv.RegisterConnect(path, handler, cfg.CorsOrigins...)
 

--- a/server/test_server.go
+++ b/server/test_server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/annexsh/annex-proto/go/gen/annex/tests/v1/testsv1connect"
@@ -20,9 +19,8 @@ import (
 )
 
 func ServeTestService(ctx context.Context, cfg TestServiceConfig) error {
-	logger := log.NewLogger("app", "annex-test-service")
-
-	srv := rpc.NewServer(fmt.Sprint(":", cfg.Port))
+	logger := log.NewLogger("service", "test_service")
+	srv := rpc.NewServer(getHostPort(cfg.Port))
 
 	pgCfg := cfg.Postgres
 	pgPool, err := postgres.OpenPool(ctx, pgCfg.User, pgCfg.Password, pgCfg.HostPort, postgres.WithMigration())
@@ -47,6 +45,7 @@ func ServeTestService(ctx context.Context, cfg TestServiceConfig) error {
 	workflowProxyClient, err := client.NewLazyClient(client.Options{
 		HostPort:  srv.GRPCAddress(),
 		Namespace: workflowservice.Namespace,
+		Logger:    logger.With("component", "temporal_client"),
 	})
 	if err != nil {
 		return err

--- a/server/util.go
+++ b/server/util.go
@@ -21,8 +21,12 @@ func serve(ctx context.Context, srv *rpc.Server, logger log.Logger) error {
 	select {
 	case <-ctx.Done():
 		logger.Info("context cancelled: stopping server")
-		return nil
+		return srv.Stop()
 	case err := <-srvErrCh:
 		return fmt.Errorf("server failed: %w", err)
 	}
+}
+
+func getHostPort(port int) string {
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }

--- a/server/workflow_proxy_server.go
+++ b/server/workflow_proxy_server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -18,13 +17,13 @@ import (
 )
 
 func ServeWorkflowProxyService(ctx context.Context, cfg WorkflowProxyServiceConfig) error {
-	logger := log.NewLogger("app", "annex-workflow-proxy-service")
-
-	srv := rpc.NewServer(fmt.Sprint(":", cfg.Port))
+	logger := log.NewLogger("service", "workflow_proxy_service")
+	srv := rpc.NewServer(getHostPort(cfg.Port))
 
 	temporalClient, err := client.NewLazyClient(client.Options{
 		HostPort:  cfg.Temporal.HostPort,
 		Namespace: workflowservice.Namespace,
+		Logger:    logger.With("component", "temporal_client"),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Changes

- Add logger to Temporal client
- Downgrade dependency `go.temporal.io/api` to v1.38.0